### PR TITLE
luma correction for Less 1.7

### DIFF
--- a/scheme.less
+++ b/scheme.less
@@ -68,7 +68,7 @@
 ///////////////////////////
 
 @sat:saturation(@seed-color);
-@luma:luma(@seed-color);
+@luma:luminance(@seed-color);
 @lit:lightness(@seed-color);
 @tone:desaturate(@seed-color,100%);
 
@@ -113,12 +113,12 @@
 
 // contrasts text against a given background color
 
-.contrast (@color) when (luma(@color) >= @luma-upper-break) {
+.contrast (@color) when (luminance(@color) >= @luma-upper-break) {
     //darker text for lighter backgrounds
     color:average(darken(@color,30%),#222);
 }
 
-.contrast (@color) when (luma(@color) < @luma-upper-break) {
+.contrast (@color) when (luminance(@color) < @luma-upper-break) {
     //white text for everything else
     color:#ffffff;
 }


### PR DESCRIPTION
Less 1.7 use a different way to calculate the luma() of a color, see:  https://github.com/less/less.js/pull/1890
luminance() gives the "old" value for backward compatibility.
